### PR TITLE
Fixmonostereo

### DIFF
--- a/src/audio-decoder.ts
+++ b/src/audio-decoder.ts
@@ -89,7 +89,7 @@ export class AudioDecoder {
                     udesc = new Uint8Array(descBuf);
                 }
             }
-            const  supported = libavs.decoder(config.codec);
+            const  supported = libavs.decoder(config.codec, config);
             /* 2. If supported is true, assign [[codec implementation]] with an
              * implementation supporting config. */
             if (supported) {
@@ -367,7 +367,7 @@ export class AudioDecoder {
     static async isConfigSupported(
         config: AudioDecoderConfig
     ): Promise<AudioDecoderSupport> {
-        const dec = libavs.decoder(config.codec);
+        const dec = libavs.decoder(config.codec, config);
         let supported = false;
         if (dec) {
             const libav = await libavs.get();

--- a/src/audio-decoder.ts
+++ b/src/audio-decoder.ts
@@ -79,17 +79,44 @@ export class AudioDecoder {
         this._p = this._p.then(async function() {
             /* 1. Let supported be the result of running the Check
              * Configuration Support algorithm with config. */
-            const supported = libavs.decoder(config.codec);
-
+            let udesc: Uint8Array;
+            if (config.description) { 
+                if (ArrayBuffer.isView(config.description)) {
+                    const descView = config.description as ArrayBufferView;
+                    udesc = new Uint8Array(descView.buffer, descView.byteOffset, descView.byteLength);
+                } else {
+                    const descBuf = config.description as ArrayBuffer;
+                    udesc = new Uint8Array(descBuf);
+                }
+            }
+            const  supported = libavs.decoder(config.codec);
             /* 2. If supported is true, assign [[codec implementation]] with an
              * implementation supporting config. */
             if (supported) {
                 const libav = self._libav = await libavs.get();
-
+                const codecpara = await libav.ff_calloc_AVCodecParameters();
+                const ps = [
+                   libav.AVCodecParameters_channels_s(codecpara, config.numberOfChannels),
+                   libav.AVCodecParameters_sample_rate_s(codecpara, config.sampleRate),
+                   libav.AVCodecParameters_codec_type_s(codecpara, 1 /*  AVMEDIA_TYPE_AUDIO */)
+                ]
+                if (!udesc) {
+                    ps.push(libav.AVCodecParameters_extradata_s(codecpara, 0));
+                    ps.push(libav.AVCodecParameters_extradata_size_s(codecpara, 0));
+                } else {                     
+                    ps.push(libav.AVCodecParameters_extradata_size_s(codecpara, udesc.byteLength));
+                    const extraDataPtr = await libav.calloc(udesc.byteLength + 64 /* AV_INPUT_BUFFER_PADDING_SIZE */, 1);
+                    ps.push(libav.copyin_u8(extraDataPtr, udesc));
+                }
+                // may be a bit faster, to wait for them all together
+                await Promise.all(ps);
+                
                 // Initialize
                 [self._codec, self._c, self._pkt, self._frame] =
-                    await libav.ff_init_decoder(supported.codec);
-                await libav.AVCodecContext_time_base_s(self._c, 1, 1000);
+                    await libav.ff_init_decoder(supported.codec, codecpara);
+                await Promise.all([ libav.AVCodecContext_time_base_s(self._c, 1, 1000),
+                    libav.free(codecpara)
+                ]);
             }
 
             /* 3. Otherwise, run the Close AudioDecoder algorithm with

--- a/src/libav.ts
+++ b/src/libav.ts
@@ -112,7 +112,7 @@ export async function load() {
  * to libav.js. Returns null if unsupported.
  */
 export function decoder(
-    codec: string | {libavjs: LibAVJSCodec}
+    codec: string | {libavjs: LibAVJSCodec}, config: any
 ): LibAVJSCodec {
     if (typeof codec === "string") {
         codec = codec.replace(/\..*/, "");
@@ -121,13 +121,25 @@ export function decoder(
         switch (codec) {
             // Audio
             case "flac":
+                if (typeof config.description === "undefined") {
+                    // description is required per spec, but one can argue, if this limitation makes sense
+                    return null;
+                }
                 break;
 
             case "opus":
+                if (typeof config.description !== "undefined") {
+                    // ogg bitstream is not supported by the current implementation
+                    return null;
+                }
                 outCodec = "libopus";
                 break;
 
             case "vorbis":
+                if (typeof config.description === "undefined") {
+                    // description is required per spec, but one can argue, if this limitation makes sense
+                    return null;
+                }
                 outCodec = "libvorbis";
                 break;
 
@@ -231,6 +243,10 @@ export function encoder(
                     if (typeof opus.usedtx === "boolean") {
                         // We don't support the usedtx option
                         return null;
+                    }
+                    if (typeof opus.format === "string") { 
+                        // ogg bitstream is not supported
+                        if (opus.format !== "opus") return null;
                     }
                 }
                 break;

--- a/src/video-decoder.ts
+++ b/src/video-decoder.ts
@@ -79,7 +79,7 @@ export class VideoDecoder {
         this._p = this._p.then(async function() {
             /* 1. Let supported be the result of running the Check
              * Configuration Support algorithm with config. */
-            const supported = libavs.decoder(config.codec);
+            const supported = libavs.decoder(config.codec, config);
 
             /* 2. If supported is true, assign [[codec implementation]] with an
              * implementation supporting config. */
@@ -350,7 +350,7 @@ export class VideoDecoder {
     static async isConfigSupported(
         config: VideoDecoderConfig
     ): Promise<VideoDecoderSupport> {
-        const dec = libavs.decoder(config.codec);
+        const dec = libavs.decoder(config.codec, config);
         let supported = false;
         if (dec) {
             const libav = await libavs.get();


### PR DESCRIPTION
The first commit adds sample rate, extradata and the number of channels as information for codec allocation.
As I went today for fixing the issues through all specifications, I have also included additional checks, if the configure format follows the spec:
As currenlty only opus bitstream format is supported, it fails if ogg is requested as indicated by the description:
https://www.w3.org/TR/webcodecs-opus-codec-registration/#audiodecoderconfig-description
flac:
https://www.w3.org/TR/webcodecs-flac-codec-registration/#audiodecoderconfig-description
and 
vorbis
https://www.w3.org/TR/webcodecs-vorbis-codec-registration/#audiodecoderconfig-description
require extradata in every case.
But I am unsure about the second commit, since it may break non-complying code, so I will revert it if you want, or you can cherrypick. 
An additional change in libav.js is required.
