### PR TITLE
Add canvas context options `desynchronized` and `willReadFrequently`

### DIFF
--- a/src/video-frame.ts
+++ b/src/video-frame.ts
@@ -67,7 +67,8 @@ export class VideoFrame {
 
         offscreenCanvas.width = width;
         offscreenCanvas.height = height;
-        const ctx = offscreenCanvas.getContext("2d") as CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
+        const options = { desynchronized: true, willReadFrequently: true } as CanvasRenderingContext2DSettings;
+        const ctx = offscreenCanvas.getContext("2d", options) as CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
         ctx.clearRect(0, 0, width, height);
         ctx.drawImage(image, 0, 0);
         this._constructBuffer(ctx.getImageData(0, 0, width, height).data, {


### PR DESCRIPTION
There is no notable performance gain in Firefox, but Chrome stops logging warning about `willReadFrequently`.