### PR TITLE
Allow overloaded constructor call `new VideoFrame(image)`

### DIFF
--- a/src/video-frame.ts
+++ b/src/video-frame.ts
@@ -26,16 +26,16 @@ let offscreenCanvas: HTMLCanvasElement | OffscreenCanvas | null = null;
 
 export class VideoFrame {
     constructor(data: CanvasImageSource | BufferSource,
-                init: VideoFrameInit | VideoFrameBufferInit) {
+                init?: VideoFrameInit | VideoFrameBufferInit) {
         if (data instanceof ArrayBuffer ||
             (<any> data).buffer instanceof ArrayBuffer) {
-            this._constructBuffer(<BufferSource> data, <VideoFrameBufferInit> init);
+            this._constructBuffer(<BufferSource> data, <VideoFrameBufferInit> init!);
         } else {
             this._constructCanvas(<CanvasImageSource> data, <VideoFrameInit> init);
         }
     }
 
-    private _constructCanvas(image: any, init: VideoFrameInit) {
+    private _constructCanvas(image: any, init?: VideoFrameInit) {
         /* The spec essentially re-specifies “draw it”, and has specific
          * instructions for each sort of thing it might be. So, we don't
          * document all the steps here, we just... draw it. */
@@ -75,11 +75,11 @@ export class VideoFrame {
             format: "RGBA",
             codedWidth: width,
             codedHeight: height,
-            timestamp: init.timestamp,
-            duration: init.duration || 0,
+            timestamp: init?.timestamp || 0,
+            duration: init?.duration || 0,
             layout: [{offset: 0, stride: width * 4}],
-            displayWidth: init.displayWidth || width,
-            displayHeight: init.displayHeight || height
+            displayWidth: init?.displayWidth || width,
+            displayHeight: init?.displayHeight || height
         });
     }
 

--- a/src/video-frame.ts
+++ b/src/video-frame.ts
@@ -25,17 +25,64 @@ import "@ungap/global-this";
 let offscreenCanvas: HTMLCanvasElement | OffscreenCanvas | null = null;
 
 export class VideoFrame {
-    constructor(data: CanvasImageSource | BufferSource,
-                init?: VideoFrameInit | VideoFrameBufferInit) {
+    constructor(data: HTMLVideoElement | VideoFrame, init?: VideoFrameInit)
+    constructor(data: CanvasImageSource, init: VideoFrameInit)
+    constructor(data: BufferSource, init: VideoFrameBufferInit)
+    constructor(data: CanvasImageSource | BufferSource | VideoFrame,
+        init?: VideoFrameInit | VideoFrameBufferInit) {
         if (data instanceof ArrayBuffer ||
-            (<any> data).buffer instanceof ArrayBuffer) {
-            this._constructBuffer(<BufferSource> data, <VideoFrameBufferInit> init!);
+            (<any>data).buffer instanceof ArrayBuffer) {
+            this._constructBuffer(<BufferSource>data, <VideoFrameBufferInit>init);
+        } else if (data instanceof VideoFrame || data instanceof globalThis.VideoFrame) {
+            const array = new Uint8Array(data.allocationSize());
+            data.copyTo(array);
+
+            this._constructBuffer(array, <VideoFrameBufferInit> {
+                transfer: [array.buffer],
+                // 1. Let format be otherFrame.format.
+                // 2. FIXME: If init.alpha is discard, assign otherFrame.format's equivalent opaque format format.
+                format: data.format,
+                // 3. Let validInit be the result of running the Validate VideoFrameInit algorithm with format and otherFrame’s [[coded width]] and [[coded height]].
+                // 4. If validInit is false, throw a TypeError.
+                // 7. Assign the following attributes from otherFrame to frame: codedWidth, codedHeight, colorSpace.
+                codedHeight: data.codedHeight,
+                codedWidth: data.codedWidth,
+                colorSpace: data.colorSpace,
+                // 8. Let defaultVisibleRect be the result of performing the getter steps for visibleRect on otherFrame.
+                // 9. Let defaultDisplayWidth, and defaultDisplayHeight be otherFrame’s [[display width]], and [[display height]] respectively.
+                // 10. Run the Initialize Visible Rect and Display Size algorithm with init, frame, defaultVisibleRect, defaultDisplayWidth, and defaultDisplayHeight.
+                visibleRect: init?.visibleRect || data.visibleRect,
+                displayHeight: init?.displayHeight || data.displayHeight,
+                displayWidth: init?.displayWidth || data.displayWidth,
+                // 11. If duration exists in init, assign it to frame’s [[duration]]. Otherwise, assign otherFrame.duration to frame’s [[duration]].
+                duration: init?.duration || data.duration,
+                // 12. If timestamp exists in init, assign it to frame’s [[timestamp]]. Otherwise, assign otherFrame’s timestamp to frame’s [[timestamp]].
+                timestamp: init?.timestamp || data.timestamp,
+                // Assign the result of calling Copy VideoFrame metadata with init’s metadata to frame.[[metadata]].
+                metadata: JSON.parse(JSON.stringify(init?.metadata))
+            });
+        } else if (data instanceof HTMLVideoElement) {
+            // Check the usability of the image argument. If this throws an exception or returns bad, then throw an InvalidStateError DOMException.
+            if (data.readyState === HTMLVideoElement.prototype.HAVE_NOTHING
+                || data.readyState === HTMLVideoElement.prototype.HAVE_METADATA) {
+                throw new DOMException("Video is not ready for reading frames", "InvalidStateError");
+            }
+
+            // If image’s networkState attribute is NETWORK_EMPTY, then throw an InvalidStateError DOMException.
+            if (data.networkState === data.NETWORK_EMPTY) {
+                throw new DOMException("Video network state is empty", "InvalidStateError");
+            }
+
+            this._constructCanvas(data, <VideoFrameInit>{
+                ...init,
+                timestamp: init?.timestamp || data.currentTime * 1e6,
+            });
         } else {
-            this._constructCanvas(<CanvasImageSource> data, <VideoFrameInit> init);
+            this._constructCanvas(<CanvasImageSource>data, <VideoFrameInit>init);
         }
     }
 
-    private _constructCanvas(image: any, init?: VideoFrameInit) {
+    private _constructCanvas(image: any, init: VideoFrameInit) {
         /* The spec essentially re-specifies “draw it”, and has specific
          * instructions for each sort of thing it might be. So, we don't
          * document all the steps here, we just... draw it. */

--- a/src/video-frame.ts
+++ b/src/video-frame.ts
@@ -67,7 +67,8 @@ export class VideoFrame {
 
         offscreenCanvas.width = width;
         offscreenCanvas.height = height;
-        const ctx = offscreenCanvas.getContext("2d") as CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
+        const options = { desynchronized: true, willReadFrequently: true } as CanvasRenderingContext2DSettings;
+        const ctx = offscreenCanvas.getContext("2d", options) as CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
         ctx.clearRect(0, 0, width, height);
         ctx.drawImage(image, 0, 0);
         this._constructBuffer(ctx.getImageData(0, 0, width, height).data, {


### PR DESCRIPTION
According to MDN Docs, the `VideoFrame` constructor can be called with one argument.

https://developer.mozilla.org/en-US/docs/Web/API/VideoFrame/VideoFrame