### PR TITLE
Adding exports.types to properly support tsc moduleResolution bundler.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "types": "src/main.ts",
   "exports": {
     "import": "./dist/libavjs-webcodecs-polyfill.mjs",
-    "default": "./dist/libavjs-webcodecs-polyfill.js"
+    "default": "./dist/libavjs-webcodecs-polyfill.js",
+    "types": "./src/main.ts"
   },
   "scripts": {
     "build": "tsc && rollup -c",


### PR DESCRIPTION
Discussion https://github.com/Yahweasel/libavjs-webcodecs-bridge/pull/9


With these settings, TypeScript won’t pick up the definitions:

```json
{
    "module": "ES2022",
    "moduleResolution": "bundler"
}
```
This pr fixes it