### PR TITLE
Update LibAV sync scaler to respect `libavOptions`

### DIFF
--- a/src/rendering.ts
+++ b/src/rendering.ts
@@ -40,7 +40,7 @@ let origCreateImageBitmap: any = null;
 
 /**
  * Load rendering capability.
- * @param libavOptions  Options to use while loading libav, only asynchronous
+ * @param libavOptions  Options to use while loading libav
  * @param polyfill  Set to polyfill CanvasRenderingContext2D.drawImage
  */
 export async function load(libavOptions: any, polyfill: boolean) {
@@ -49,7 +49,7 @@ export async function load(libavOptions: any, polyfill: boolean) {
         // Make sure the worker code doesn't run
         (<any> libav.LibAVWrapper).nolibavworker = true;
     }
-    scalerSync = await libav.LibAVWrapper!.LibAV({noworker: true});
+    scalerSync = await libav.LibAVWrapper!.LibAV({ ...libavOptions, noworker: true});
     scalerAsync = await libav.LibAVWrapper!.LibAV(libavOptions);
 
     // Polyfill drawImage


### PR DESCRIPTION
First, thanks for the incredible work on this library!

I've been attempting to use this library in my application through our bundler, which has me supplying `LibAV`, `libAvOptions.factory`, and `libavOptions.wasmurl` manually. I'm getting an error loading this polyfill, however. `scalerAsync` respects these custom path options, but `scalerSync` doesn't. This results in an unhandled error. I see this is explicitly the case in the docstring for `rendering.load`, but I can't think of a good reason for that - it seems that these two LibAV instances should be the same except for the `noworker: true` option?

Anyway, figured I'd attempt an upstream, if not I will just end up patching this in locally.