### PR TITLE
Fix AudioData.fromNative method

### DIFF
--- a/src/audio-data.ts
+++ b/src/audio-data.ts
@@ -154,7 +154,7 @@ export class AudioData {
             format: ad.format,
             planeIndex: 0
         });
-        const data = new Uint8Array(sizePerPlane);
+        const data = new Uint8Array(sizePerPlane * planes);
         for (let p = 0; p < planes; p++) {
             ad.copyTo(data.subarray(p * sizePerPlane), {
                 format: ad.format,


### PR DESCRIPTION
It seems this method never worked correctly for AudioData with more than one channel. Explanation of the bug: In the `data` variable, we allocate space for only one plane, but in a loop, we're trying to write data for all channels into that `data` variable, which fails with an error.